### PR TITLE
fix playback of audio files with abs path on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,14 +26,12 @@
         "d3": "^7.8.2",
         "lit": "^2.8.0",
         "mobx": "^6.6.1",
-        "path-browserify": "^1.0.1",
         "pretty-bytes": "^6.0.0",
         "tauri-plugin-sqlite-api": "github:lzdyes/tauri-plugin-sqlite#v0.1.1"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^1.4.0",
         "@types/d3": "^7.4.0",
-        "@types/path-browserify": "^1.0.0",
         "typescript": "^5.2.2",
         "vite": "^4.4.0"
       }
@@ -919,12 +917,6 @@
       "version": "7946.0.10",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
       "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
-      "dev": true
-    },
-    "node_modules/@types/path-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/path-browserify/-/path-browserify-1.0.0.tgz",
-      "integrity": "sha512-XMCcyhSvxcch8b7rZAtFAaierBYdeHXVvg2iYnxOV0MCQHmPuRRmGZPFDRzPayxcGiiSL1Te9UIO+f3cuj0tfw==",
       "dev": true
     },
     "node_modules/@types/trusted-types": {
@@ -1840,11 +1832,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,14 +30,12 @@
     "d3": "^7.8.2",
     "lit": "^2.8.0",
     "mobx": "^6.6.1",
-    "path-browserify": "^1.0.1",
     "pretty-bytes": "^6.0.0",
     "tauri-plugin-sqlite-api": "github:lzdyes/tauri-plugin-sqlite#v0.1.1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^1.4.0",
     "@types/d3": "^7.4.0",
-    "@types/path-browserify": "^1.0.0",
     "typescript": "^5.2.2",
     "vite": "^4.4.0"
   },

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -91,7 +91,7 @@ impl Playback {
         // handle initialize errors
         if self.init_error.lock().unwrap().is_some() {
             return Err(anyhow!(
-                "Can't play file: Audio playback failed to intialize.",
+                "Can't play file: Audio playback failed to initialize.",
             ));
         }
 
@@ -120,7 +120,7 @@ impl Playback {
         // handle initialize errors
         if self.init_error.lock().unwrap().is_some() {
             return Err(anyhow!(
-                "Can't seek file: Audio playback failed to intialize.",
+                "Can't seek file: Audio playback failed to initialize.",
             ));
         }
         // send the source to the playback thread and start playing
@@ -141,7 +141,7 @@ impl Playback {
         // handle initialize errors
         if self.init_error.lock().unwrap().is_some() {
             return Err(anyhow!(
-                "Can't play file: Audio playback failed to intialize.",
+                "Can't play file: Audio playback failed to initialize.",
             ));
         }
         // stop playing
@@ -207,6 +207,7 @@ pub fn send_playback_position_event(
     _context: Option<AudioFilePlaybackStatusContext>
 ) {
     #[derive(Clone, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
     struct PlaybackPositionEvent {
         file_id: AudioFilePlaybackId,
         file_path: String,
@@ -233,6 +234,7 @@ pub fn send_playback_finished_event(
     _context: Option<AudioFilePlaybackStatusContext>
 ) {
     #[derive(Clone, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
     struct PlaybackFinishedEvent {
         file_id: AudioFilePlaybackId,
         file_path: String,

--- a/src/app-state.ts
+++ b/src/app-state.ts
@@ -66,6 +66,7 @@ class AppState {
   async openDatabase(filename: string): Promise<void> {
     ++this.isLoadingDatabase;
     try {
+      this.selectedFilePath = "";
       await this._database.open(filename);
       this.databasePath = filename;
       this.databaseError = "";
@@ -136,7 +137,7 @@ class AppState {
     }
   }
 
-  // generatre plot for the given database
+  // generate plot for the given database
   @mobx.action
   async generateMap(): Promise<PlotEntry[]> {
     

--- a/src/components/file-list.ts
+++ b/src/components/file-list.ts
@@ -89,7 +89,8 @@ export class FileList extends MobxLitElement {
   }
 
   private _playFile(file: File) {
-    playAudioFile(appState.databasePath, file.filename)
+    appState.fileAbsPath(file.filename)
+      .then(playAudioFile)
       .catch(err => {
         console.warn("Audio playback error: %s", err.message || String(err))
       });

--- a/src/components/file-map-plot.ts
+++ b/src/components/file-map-plot.ts
@@ -98,9 +98,10 @@ export class FileMapPlot extends LitElement {
       // Play the file
       if (appState.autoPlayFilesInGrid && this._playingPointIndex != closestPoint.index) {
         this._playingPointIndex = closestPoint.index;
-        playAudioFile(appState.databasePath, closestPoint.filename)
+        appState.fileAbsPath(closestPoint.filename)
+          .then(playAudioFile)
           .catch((err) => { 
-            console.log("Audio playback failed: %s", err)
+            console.warn("Audio playback failed: %s", err)
           });
       }
     } else {
@@ -124,9 +125,10 @@ export class FileMapPlot extends LitElement {
       // redraw all points
       this._drawPlotPoints(xScale, yScale, context, data);
       // play file
-      playAudioFile(appState.databasePath, closestPoint.filename)
-        .catch((err) => { 
-          console.log("Audio playback failed: %s", err)
+      appState.fileAbsPath(closestPoint.filename)
+        .then(playAudioFile)
+        .catch((err) => {
+          console.warn("Audio playback failed: %s", err)
         });
       // and select it
       appState.selectedFilePath = closestPoint.filename;

--- a/src/components/file-waveview-plot.ts
+++ b/src/components/file-waveview-plot.ts
@@ -258,8 +258,8 @@ export class FileWaveViewPlot extends LitElement {
       .then((absSelectedFilePath) => {
         this._removePlaybackPositionListener = addPlaybackPositionEventListener(async (event) => {
           try {
-            if (absSelectedFilePath == event.file_path || 
-                absSelectedFilePath == await path.normalize(event.file_path)) {
+            if (absSelectedFilePath == event.filePath || 
+                absSelectedFilePath == await path.normalize(event.filePath)) {
               if (this._removePlaybackPositionListener !== undefined) { // still connected?
                 this._drawPlaybackPosition(xScale, yScale, context, event.position);
               }
@@ -270,8 +270,8 @@ export class FileWaveViewPlot extends LitElement {
         });
         this._removePlaybackFinishedListener = addPlaybackFinishedEventListener(async (event) => {
           try {
-            if (absSelectedFilePath == event.file_path || 
-                absSelectedFilePath == await path.normalize(event.file_path)) {
+            if (absSelectedFilePath == event.filePath || 
+                absSelectedFilePath == await path.normalize(event.filePath)) {
               if (this._removePlaybackFinishedListener !== undefined) {  // still connected?
                 this._drawPlaybackPosition(xScale, yScale, context, -1);
               }

--- a/src/controllers/backend/audio.ts
+++ b/src/controllers/backend/audio.ts
@@ -1,4 +1,3 @@
-import path from 'path-browserify';
 import { invoke } from '@tauri-apps/api/tauri'
 import { listen } from '@tauri-apps/api/event'
 
@@ -31,19 +30,14 @@ export function playingAudioFiles(): {id: FileId, path: String}[] {
 
 // -------------------------------------------------------------------------------------------------
 
-// Play back a single audio file from a database. This stops all previously playing files.
-export async function playAudioFile(dbPath: string, filePath: string): Promise<FileId> {
-  let absPath = path.normalize(filePath.replace(/\\/g, "/"));
-  if (! path.isAbsolute(absPath)) {
-    let dirname = path.dirname(dbPath.replace(/\\/g, "/"));
-    absPath = path.join(dirname, absPath);
-  }
+// Play back a single audio file. This stops all previously playing files.
+export async function playAudioFile(filePath: string): Promise<FileId> {
   // stop all playing files
   for (let id of playingFiles.keys()) {
     await invoke<void>('stop_audio_file', { fileId: id });
   }
   // start playback of the new file
-  let fileId = await invoke<FileId>('play_audio_file', { filePath: absPath });
+  let fileId = await invoke<FileId>('play_audio_file', { filePath: filePath });
   playingFiles.set(fileId, filePath);
   return fileId;
 }

--- a/src/controllers/backend/audio.ts
+++ b/src/controllers/backend/audio.ts
@@ -46,8 +46,8 @@ export async function playAudioFile(filePath: string): Promise<FileId> {
 
 // register a new playback position change listener. returns a function to remove the listener again.
 export interface PlaybackPositionEvent {
-  file_id: FileId,
-  file_path: string, 
+  fileId: FileId,
+  filePath: string, 
   position: number 
 };
 
@@ -67,8 +67,8 @@ export function addPlaybackPositionEventListener(
 
 // register a new playback finished listener. returns a function to remove the listener again.
 export interface PlaybackFinishedEvent {
-  file_id: FileId,
-  file_path: string,
+  fileId: FileId,
+  filePath: string,
 };
 
 export function addPlaybackFinishedEventListener(
@@ -97,6 +97,6 @@ listen<PlaybackPositionEvent>("audio_playback_position", (event) => {
 });
 
 listen<PlaybackFinishedEvent>("audio_playback_finished", (event) => {
-  playingFiles.delete(event.payload.file_id);
+  playingFiles.delete(event.payload.fileId);
   playbackFinishedListeners.forEach(l => l.func(event.payload));
 });

--- a/src/controllers/backend/waveform.ts
+++ b/src/controllers/backend/waveform.ts
@@ -1,5 +1,4 @@
 import { invoke } from '@tauri-apps/api/tauri'
-import path from 'path-browserify';
 
 // -------------------------------------------------------------------------------------------------
 
@@ -21,12 +20,7 @@ export interface WaveformPoint {
   fn generate_waveform `src-tauri/waveform`
  */
 
-export async function generateWaveform(dbPath: string, filePath: string, resolution: number) {
-  let absPath = path.normalize(filePath.replace(/\\/g, "/"));
-  if (! path.isAbsolute(absPath)) {
-    let dirname = path.dirname(dbPath.replace(/\\/g, "/"));
-    absPath = path.join(dirname, absPath);
-  } 
-  return invoke<WaveformPoint[]>('generate_waveform', { filePath: absPath, resolution: Math.round(resolution) });
+export async function generateWaveform(filePath: string, resolution: number) {
+  return invoke<WaveformPoint[]>('generate_waveform', { filePath: filePath, resolution: Math.round(resolution) });
 }
 


### PR DESCRIPTION
use tauri's path impl instead of path-browserify in the UI

- path-browserify works with posix paths only and thus won't work with windows paths
- tauri's path impl unfortunately is async, so audio path handling must be async in the UI now too